### PR TITLE
Fix infinite loading when failed to create headless browser

### DIFF
--- a/client.py
+++ b/client.py
@@ -2,6 +2,7 @@ import asyncio
 import os
 import threading
 import unittest
+import traceback
 from datetime import datetime, timedelta
 from typing import Dict, List
 
@@ -29,8 +30,11 @@ class CachedVersionFetcher(VersionFetcher):
     async def get(self):
         currentTime = datetime.now()
         if (currentTime - self.last) >= self.timeout:
-            self.cache = await self.delegation.get()
-            self.last = currentTime
+            try:
+                self.cache = await self.delegation.get()
+                self.last = currentTime
+            except pyppeteer.errors.BrowserError:
+                traceback.print_exc()
         return self.cache
 
 

--- a/tests/test-cache-fallback.py
+++ b/tests/test-cache-fallback.py
@@ -1,0 +1,49 @@
+import unittest
+import asyncio
+
+from datetime import timedelta
+
+from client import (
+    VersionFetcher,
+    CachedVersionFetcher
+)
+
+import pyppeteer
+
+
+class PseudoVersionFetcher(VersionFetcher):
+
+    def __init__(self):
+        self.initial_run = True
+
+    async def get(self):
+        if self.initial_run:
+            self.initial_run = False
+            return "hello"
+        raise pyppeteer.errors.BrowserError()
+
+
+class TestCacheFallback(unittest.TestCase):
+
+    def test_raise(self):
+        loop = asyncio.get_event_loop()
+        target = PseudoVersionFetcher()
+        loop.run_until_complete(target.get())
+        self.assertRaises(pyppeteer.errors.BrowserError,
+                          lambda: loop.run_until_complete(target.get()))
+
+    def test_fallback(self):
+        target = CachedVersionFetcher(
+            PseudoVersionFetcher(),
+            timedelta(0)  # instantly cache invalidation
+        )
+
+        loop = asyncio.get_event_loop()
+        healthyResponse = loop.run_until_complete(target.get())
+        fallbackedResponse = loop.run_until_complete(target.get())
+
+        self.assertEquals(healthyResponse, fallbackedResponse)
+
+
+if __name__ == "__main__":
+    unittest.main()


### PR DESCRIPTION
Fixes "Browser closed unexpectedly: Resource temporarily unavailable (11)" errors.